### PR TITLE
raise lower opacity limit to .3 to keep titles legible

### DIFF
--- a/js/models/doc.js
+++ b/js/models/doc.js
@@ -41,10 +41,10 @@ define(function(require) {
       //Time passed since last this document was edited the last time in milliseconds
       var diff = (new Date().getTime() - this.get('lastEdited'));
       //The older the document the smaller the opacity
-      //but the opacity is allway between 0.1 and 1
+      //but the opacity is allway between 0.3 and 1
       //For documents older than 2 Weeks the opacity won't change anymore
       var limit = 14 * 86400000;
-      var opacity = diff > limit ? 0.1 : Math.round( (0.1 + ((limit - diff) / limit) * 0.9) * 100 ) / 100;
+      var opacity = diff > limit ? 0.3 : Math.round( (0.3 + ((limit - diff) / limit) * 0.7) * 100 ) / 100;
       return opacity;
     }
 


### PR DESCRIPTION
The .1 opacity is too low for the document titles. Increased it to .3 to keep the titles legible. @jorin-vogel are all the values changed correctly (especially the 0.9 to 0.7)?
