### PR TITLE
only handle 'change' events coming from remote

### DIFF
--- a/js/litewrite.js
+++ b/js/litewrite.js
@@ -24,7 +24,7 @@ define(function(require) {
       remoteStorage.displayWidget('remotestorage-connect');
 
       remoteStorageDocuments.onChange('notes', function(event) {
-        if(event.origin === 'remote') {
+        if(event.origin !== 'window') {
           fetch();
         }
       });


### PR DESCRIPTION
Whenever a local write is made, that triggers a "change" with origin: "window". Updating any UI then is unnecessary, since the changes have already propagated through the backbone model before the "change" event from remoteStorage.js is even fired.
