### PR TITLE
Fix typos on readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,9 +28,10 @@ Jorin & Jan-Christoph
 
 Play with the [development version](http://litewrite.github.com/litewrite), check out [issues](http://github.com/litewrite/litewrite/issues) and dive into the code if you like. Set up your development environment:
 
-1. git clone http://github.com/litewrite/litewrite
+1. git clone https://github.com/litewrite/litewrite.git
+2. cd litewrite
 2. Install [node.js](http://nodejs.org/#download)
-3. Install grunt gobally via (`sudo `)`npm install -g grunt-cli`
+3. Install grunt gobally via (`sudo`) `npm install -g grunt-cli`
 4. Run `npm install` to install the development dependencies
 5. `grunt` to start a web server at [http://localhost:8000](http://localhost:8000)
 

--- a/readme.md
+++ b/readme.md
@@ -30,10 +30,10 @@ Play with the [development version](http://litewrite.github.com/litewrite), chec
 
 1. git clone https://github.com/litewrite/litewrite.git
 2. cd litewrite
-2. Install [node.js](http://nodejs.org/#download)
-3. Install grunt gobally via (`sudo`) `npm install -g grunt-cli`
-4. Run `npm install` to install the development dependencies
-5. `grunt` to start a web server at [http://localhost:8000](http://localhost:8000)
+3. Install [node.js](http://nodejs.org/#download)
+4. Install grunt gobally via (`sudo`)` npm install -g grunt-cli`
+5. Run `npm install` to install the development dependencies
+6. `grunt` to start a web server at [http://localhost:8000](http://localhost:8000)
 
 ### Building the production version
 


### PR DESCRIPTION
### Under the "Contribute" Section:

1. `git clone http://github.com/litewrite/litewrite` is not a correct git command and the url is HTTP not HTTPS.
2. Running `npm install` to install the development dependencies will cause an error `(npm error 34)` if the user is not working on the cloned project since `package.json` is needed to fetch other required packages.