### PR TITLE
Add timeAgo to russian translation

### DIFF
--- a/src/translations/ru.js
+++ b/src/translations/ru.js
@@ -11,31 +11,19 @@ module.exports = {
   open:     'открыть',
   modified: 'изменен',
   welcome:  require('./welcome-ru.txt'),
-  secondAgo:   function ()  { return 'секунду назад'     ; },
-  secondsAgo:  function (x) { return x + ' seconds ago' ; },
-  minuteAgo:   function ()  { return 'минуту назад'     ; },
-  minutesAgo:  function (x) { return x + ' minutes ago' ; },
-  hourAgo:     function ()  { return 'час назад'      ; },
-  hoursAgo:    function (x) { return x + ' hours ago'   ; },
-  dayAgo:      function ()  { return 'день назад'        ; },
-  daysAgo:     function (x) { return x + ' days ago'    ; },
-  monthAgo:    function ()  { return 'месяц назад'      ; },
-  monthsAgo:   function (x) { return x + ' months ago'  ; },
-  yearAgo:     function ()  { return 'год назад'       ; },
-  yearsAgo:    function (x) { return x + ' years ago'   ; }
   timeAgo: function relativeTimeWithPlural(number, key) {
-        var format = {
-            'mm': 'минуту_минуты_минут',
-            'hh': 'час_часа_часов',
-            'dd': 'день_дня_дней',
-            'MM': 'месяц_месяца_месяцев',
-            'yy': 'год_года_лет'
-        };
-        if (key === 'm') {
-            return 'минуту';
-        }
-        else {
-            return number + ' ' + plural(format[key], +number);
-        }
-    }
+      var format = {
+          'mm': 'минуту_минуты_минут',
+          'hh': 'час_часа_часов',
+          'dd': 'день_дня_дней',
+          'MM': 'месяц_месяца_месяцев',
+          'yy': 'год_года_лет'
+      };
+      if (key === 'm') {
+          return 'минуту';
+      }
+      else {
+          return number + ' ' + plural(format[key], +number);
+      }
+  }
 };

--- a/src/translations/ru.js
+++ b/src/translations/ru.js
@@ -1,3 +1,8 @@
+function plural(word, num) {
+  var forms = word.split('_');
+  return num % 10 === 1 && num % 100 !== 11 ? forms[0] : (num % 10 >= 2 && num % 10 <= 4 && (num % 100 < 10 || num % 100 >= 20) ? forms[1] : forms[2]);
+}
+    
 module.exports = {
   emptyDoc: 'Пишите …',
   search:   'Искать …',
@@ -6,16 +11,31 @@ module.exports = {
   open:     'открыть',
   modified: 'изменен',
   welcome:  require('./welcome-ru.txt'),
-  secondAgo:   function ()  { return 'a second ago'     ; },
+  secondAgo:   function ()  { return 'секунду назад'     ; },
   secondsAgo:  function (x) { return x + ' seconds ago' ; },
-  minuteAgo:   function ()  { return 'a minute ago'     ; },
+  minuteAgo:   function ()  { return 'минуту назад'     ; },
   minutesAgo:  function (x) { return x + ' minutes ago' ; },
-  hourAgo:     function ()  { return 'an hour ago'      ; },
+  hourAgo:     function ()  { return 'час назад'      ; },
   hoursAgo:    function (x) { return x + ' hours ago'   ; },
-  dayAgo:      function ()  { return 'a day ago'        ; },
+  dayAgo:      function ()  { return 'день назад'        ; },
   daysAgo:     function (x) { return x + ' days ago'    ; },
-  monthAgo:    function ()  { return 'a month ago'      ; },
+  monthAgo:    function ()  { return 'месяц назад'      ; },
   monthsAgo:   function (x) { return x + ' months ago'  ; },
-  yearAgo:     function ()  { return 'a year ago'       ; },
+  yearAgo:     function ()  { return 'год назад'       ; },
   yearsAgo:    function (x) { return x + ' years ago'   ; }
+  timeAgo: function relativeTimeWithPlural(number, key) {
+        var format = {
+            'mm': 'минуту_минуты_минут',
+            'hh': 'час_часа_часов',
+            'dd': 'день_дня_дней',
+            'MM': 'месяц_месяца_месяцев',
+            'yy': 'год_года_лет'
+        };
+        if (key === 'm') {
+            return 'минуту';
+        }
+        else {
+            return number + ' ' + plural(format[key], +number);
+        }
+    }
 };


### PR DESCRIPTION
I propose using timeAgo function for all other languages. This would work for most of other slavic languages, like Ukrainian and Belorussian (which also use three plural forms)