### PR TITLE
Prevents the save shortcut.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -24,6 +24,7 @@ utils.escapeRegExp = function(str) { return str.replace(/[-\/\\^$*+?.()|[\]{}]/g
 
 
 utils.modKey = utils.isMac ? { name: 'ctrlKey', code: 17 } : { name: 'altKey', code: 18 };
+utils.metaKey = utils.isMac ? 'metaKey' : 'ctrlKey';
 
 // in seconds
 var hour  = 3600;
@@ -50,7 +51,7 @@ utils.timeAgo = function(date) {
   });
 
   if (!quantifier) return;
-  
+
   var count = Math.round(diff / quantifier.time);
   return translations[quantifier.name](count);
 };

--- a/src/views/app.js
+++ b/src/views/app.js
@@ -80,10 +80,15 @@ var AppView = Backbone.View.extend({
 
   // global key handler for shortcuts
   handleKey: function(e) {
-    if (e.which === 9) return e.preventDefault(); // prevent tabkey
+    var tabKey = e.keyCode === 9
+
+    var sKey = e.keyCode === 83;
+    var saveShortcut = sKey && e[utils.metaKey];
+
+    if (tabKey || saveShortcut) return e.preventDefault();
     if (! e[utils.modKey.name] ) return;
     this.aside.show();
-    var shortcut = this.shortcuts[e.which];
+    var shortcut = this.shortcuts[e.keyCode];
     if (shortcut) return shortcut.call(this, e);
   },
 


### PR DESCRIPTION
On OSX CMD-S, else CTRL-S.
Also changed key event handling to use `keyCode` instead of `which` since this is the supported one.
Fixes #182.