### PR TITLE
translating unshare

### DIFF
--- a/src/translations/fr.js
+++ b/src/translations/fr.js
@@ -3,7 +3,7 @@ module.exports = {
   search: 'Rechercher …',
   footer: 'Ecrivez léger, écrivez libre !',
   share: 'partager',
-  unshare: 'unshare',
+  unshare: 'cacher',
   open: 'ouvrir',
   modified: 'dernière modification',
   welcome: require('./welcome-fr.txt'),


### PR DESCRIPTION
Translated as "hide", following the German choice of "verstecken".
Literally, "unshare" would be "départager", but that's not very clear indeed