### PR TITLE
Change sidebar toggle hotkey to Ctrl/Alt+Space

### DIFF
--- a/src/translations/welcome.txt
+++ b/src/translations/welcome.txt
@@ -17,3 +17,4 @@ By the way, if you use a keyboard you can also use shortcuts to work more quickl
 - {Alt} + f: focus search field
 - {Alt} + ↑: switch to note above
 - {Alt} + ↓: switch to note below
+- {Alt} + Space: open sidebar when collapsed

--- a/src/views/app.js
+++ b/src/views/app.js
@@ -110,8 +110,6 @@ var AppView = Backbone.View.extend({
     const hotKey = (utils.isMac && e.altKey) || e.ctrlKey
     if (!hotKey) return
 
-    this.aside.show()
-
     var shortcut = this.shortcuts[e.keyCode]
     if (!shortcut) {
       return
@@ -124,6 +122,9 @@ var AppView = Backbone.View.extend({
   },
 
   shortcuts: {
+    32: function space () {
+      this.aside.toggle()
+    },
     68: function d () {
       this.newDoc()
     },


### PR DESCRIPTION
As mentioned in #300, using Ctrl alone to toggle the sidebar is annoying, since it also toggles when you use cursor movement shortcuts (e.g. Ctrl+RightArrow or Ctrl+Home). 

This PR changes the sidebar toggle to Ctrl+Space to avoid that problem.

Note that the sidebar does not open when you switch note with Ctrl+UpArrow/DownArrow or when you create a new note with Ctrl+d, but it does still open when you focus the search field with Ctrl+f